### PR TITLE
PSR 15 handlers

### DIFF
--- a/.docheader
+++ b/.docheader
@@ -1,7 +1,7 @@
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-%year% prooph software GmbH <contact@prooph.de>
- * (c) 2016-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-%year% prooph software GmbH <contact@prooph.de>
+ * (c) 2018-%year% Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,6 @@ before_script:
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi
-  - rm data/cache/config-cache.php
   - ./vendor/bin/php-cs-fixer fix -v --diff --dry-run
   - ./vendor/bin/docheader check config/ public/ src/ tests/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,6 @@ language: php
 
 dist: trusty
 
-addons:
-  postgresql: "9.6"
-
 matrix:
   fast_finish: true
   include:
@@ -30,12 +27,9 @@ cache:
 
 before_script:
   - mkdir -p "$HOME/.php-cs-fixer"
-  - cp composer.json.dist composer.json
-  - cp config/pipeline.php.dist config/pipeline.php
   - phpenv config-rm xdebug.ini
   - composer self-update
   - composer update $DEPENDENCIES
-  - psql -c 'create database event_store_tests;' -U postgres
 
 script:
   - if [[ $TEST_COVERAGE == 'true' ]]; then php -dzend_extension=xdebug.so ./vendor/bin/phpunit --coverage-text --coverage-clover ./build/logs/clover.xml; else ./vendor/bin/phpunit; fi

--- a/composer.json
+++ b/composer.json
@@ -32,6 +32,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",
+        "phpspec/prophecy": "^1.7",
         "prooph/php-cs-fixer-config": "^0.1.1",
         "satooshi/php-coveralls": "^1.0",
         "malukenho/docheader": "^0.1.4"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "require-dev": {
         "phpunit/phpunit": "^6.0",
         "phpspec/prophecy": "^1.7",
-        "prooph/php-cs-fixer-config": "^0.1.1",
+        "prooph/php-cs-fixer-config": "^0.2",
         "satooshi/php-coveralls": "^1.0",
         "malukenho/docheader": "^0.1.4"
     },

--- a/composer.json
+++ b/composer.json
@@ -28,8 +28,7 @@
         "psr/container": "^1.0",
         "prooph/event-store" : "^7.2",
         "roave/security-advisories": "dev-master",
-        "psr/http-server-middleware": "^1.0",
-        "http-interop/http-middleware": "^0.5.0"
+        "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0",

--- a/composer.json
+++ b/composer.json
@@ -28,11 +28,11 @@
         "psr/container": "^1.0",
         "prooph/event-store" : "^7.2",
         "roave/security-advisories": "dev-master",
-        "zendframework/zend-expressive-helpers": "^4.0",
-        "psr/http-server-middleware": "^1.0"
+        "psr/http-server-middleware": "^1.0",
+        "http-interop/http-middleware": "^0.5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.0",
+        "phpunit/phpunit": "^6.0",
         "prooph/php-cs-fixer-config": "^0.1.1",
         "satooshi/php-coveralls": "^1.0",
         "malukenho/docheader": "^0.1.4"

--- a/src/Action/DeleteProjection.php
+++ b/src/Action/DeleteProjection.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/DeleteProjection.php
+++ b/src/Action/DeleteProjection.php
@@ -1,0 +1,61 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DeleteProjection implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $projectionName = urldecode($request->getAttribute('name'));
+        $deleteEmittedEvents = $request->getAttribute('deleteEmittedEvents');
+
+        switch ($deleteEmittedEvents) {
+            case 'false':
+                $deleteEmittedEvents = false;
+                break;
+            case 'true':
+                $deleteEmittedEvents = true;
+                break;
+        }
+
+        try {
+            $this->projectionManager->deleteProjection($projectionName, $deleteEmittedEvents);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Action/DeleteStream.php
+++ b/src/Action/DeleteStream.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/DeleteStream.php
+++ b/src/Action/DeleteStream.php
@@ -1,0 +1,52 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class DeleteStream implements RequestHandlerInterface
+{
+    /**
+     * @var EventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(EventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $streamName = urldecode($request->getAttribute('streamname'));
+
+        try {
+            $this->eventStore->delete(new StreamName($streamName));
+        } catch (StreamNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Action/FetchCategoryNames.php
+++ b/src/Action/FetchCategoryNames.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchCategoryNames.php
+++ b/src/Action/FetchCategoryNames.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchCategoryNames implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ReadOnlyEventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $filter = $request->getAttribute('filter');
+
+        if (null !== $filter) {
+            $filter = urldecode($filter);
+        }
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $categoryNames = $this->eventStore->fetchCategoryNames($filter, (int) $limit, (int) $offset);
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($categoryNames);
+    }
+}

--- a/src/Action/FetchCategoryNamesRegex.php
+++ b/src/Action/FetchCategoryNamesRegex.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchCategoryNamesRegex.php
+++ b/src/Action/FetchCategoryNamesRegex.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchCategoryNamesRegex implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ReadOnlyEventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $filter = urldecode($request->getAttribute('filter'));
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $categoryNames = $this->eventStore->fetchCategoryNamesRegex($filter, (int) $limit, (int) $offset);
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($categoryNames);
+    }
+}

--- a/src/Action/FetchProjectionNames.php
+++ b/src/Action/FetchProjectionNames.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchProjectionNames.php
+++ b/src/Action/FetchProjectionNames.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchProjectionNames implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $filter = $request->getAttribute('filter');
+
+        if (null !== $filter) {
+            $filter = urldecode($filter);
+        }
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $projectionNames = $this->projectionManager->fetchProjectionNames($filter, (int) $limit, (int) $offset);
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($projectionNames);
+    }
+}

--- a/src/Action/FetchProjectionNamesRegex.php
+++ b/src/Action/FetchProjectionNamesRegex.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchProjectionNamesRegex.php
+++ b/src/Action/FetchProjectionNamesRegex.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchProjectionNamesRegex implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $filter = urldecode($request->getAttribute('filter'));
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $projectionNames = $this->projectionManager->fetchProjectionNamesRegex($filter, (int) $limit, (int) $offset);
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($projectionNames);
+    }
+}

--- a/src/Action/FetchProjectionState.php
+++ b/src/Action/FetchProjectionState.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchProjectionState.php
+++ b/src/Action/FetchProjectionState.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchProjectionState implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $name = $request->getAttribute('name');
+
+        try {
+            $state = $this->projectionManager->fetchProjectionState($name);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($state);
+    }
+}

--- a/src/Action/FetchProjectionStatus.php
+++ b/src/Action/FetchProjectionStatus.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchProjectionStatus.php
+++ b/src/Action/FetchProjectionStatus.php
@@ -1,0 +1,75 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchProjectionStatus implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $name = $request->getAttribute('name');
+
+        try {
+            $status = $this->projectionManager->fetchProjectionStatus($name);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        //@Todo: Use transformer with ['status' => $status->getName()] but take care of http-lug-event-store!
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        $body = $this->responsePrototype->getBody();
+        $body->rewind();
+        $body->write($status->getName());
+
+        return $this->responsePrototype->withStatus(200)->withBody($body);
+    }
+}

--- a/src/Action/FetchProjectionStreamPositions.php
+++ b/src/Action/FetchProjectionStreamPositions.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchProjectionStreamPositions.php
+++ b/src/Action/FetchProjectionStreamPositions.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchProjectionStreamPositions implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $name = $request->getAttribute('name');
+
+        try {
+            $streamPositions = $this->projectionManager->fetchProjectionStreamPositions($name);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($streamPositions);
+    }
+}

--- a/src/Action/FetchStreamMetadata.php
+++ b/src/Action/FetchStreamMetadata.php
@@ -1,0 +1,71 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchStreamMetadata implements RequestHandlerInterface
+{
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ReadOnlyEventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $streamName = urldecode($request->getAttribute('streamname'));
+
+        try {
+            $metadata = $this->eventStore->fetchStreamMetadata(new StreamName($streamName));
+        } catch (StreamNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($metadata);
+    }
+}

--- a/src/Action/FetchStreamMetadata.php
+++ b/src/Action/FetchStreamMetadata.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchStreamNames.php
+++ b/src/Action/FetchStreamNames.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchStreamNames.php
+++ b/src/Action/FetchStreamNames.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Interop\Http\ServerMiddleware\DelegateInterface;
+use Interop\Http\ServerMiddleware\MiddlewareInterface;
+use Prooph\EventStore\Http\Api\Model\MetadataMatcherBuilder;
+use Prooph\EventStore\Http\Api\Transformer\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ServerRequestInterface;
+use Zend\Diactoros\Response\EmptyResponse;
+
+final class FetchStreamNames implements MiddlewareInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    public function __construct(ReadOnlyEventStore $eventStore)
+    {
+        $this->eventStore = $eventStore;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function process(ServerRequestInterface $request, DelegateInterface $delegate)
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return new EmptyResponse(415);
+        }
+
+        $filter = $request->getAttribute('filter');
+
+        if (null !== $filter) {
+            $filter = urldecode($filter);
+        }
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $metadataMatcherBuilder = new MetadataMatcherBuilder();
+        $metadataMatcher = $metadataMatcherBuilder->createMetadataMatcherFrom($request, false);
+
+        $streamNames = $this->eventStore->fetchStreamNames($filter, $metadataMatcher, (int) $limit, (int) $offset);
+
+        $streamNames = array_map(
+            function (StreamName $streamName): string {
+                return $streamName->toString();
+            },
+            $streamNames
+        );
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($streamNames);
+    }
+}

--- a/src/Action/FetchStreamNamesRegex.php
+++ b/src/Action/FetchStreamNamesRegex.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/FetchStreamNamesRegex.php
+++ b/src/Action/FetchStreamNamesRegex.php
@@ -1,0 +1,85 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Model\MetadataMatcherBuilder;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class FetchStreamNamesRegex implements RequestHandlerInterface
+{
+    private const DEFAULT_LIMIT = 20;
+    private const DEFAULT_OFFSET = 0;
+
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ReadOnlyEventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $filter = urldecode($request->getAttribute('filter'));
+
+        $queryParams = $request->getQueryParams();
+
+        $limit = $queryParams['limit'] ?? self::DEFAULT_LIMIT;
+        $offset = $queryParams['offset'] ?? self::DEFAULT_OFFSET;
+
+        $metadataMatcherBuilder = new MetadataMatcherBuilder();
+        $metadataMatcher = $metadataMatcherBuilder->createMetadataMatcherFrom($request, false);
+
+        $streamNames = $this->eventStore->fetchStreamNamesRegex($filter, $metadataMatcher, (int) $limit, (int) $offset);
+
+        $streamNames = array_map(
+            function (StreamName $streamName): string {
+                return $streamName->toString();
+            },
+            $streamNames
+        );
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        return $transformer->createResponse($streamNames);
+    }
+}

--- a/src/Action/HasStream.php
+++ b/src/Action/HasStream.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/HasStream.php
+++ b/src/Action/HasStream.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class HasStream implements RequestHandlerInterface
+{
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ReadOnlyEventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $streamName = urldecode($request->getAttribute('streamname'));
+
+        if ($this->eventStore->hasStream(new StreamName($streamName))) {
+            return $this->responsePrototype->withStatus(200);
+        }
+
+        return $this->responsePrototype->withStatus(404);
+    }
+}

--- a/src/Action/HasStream.php
+++ b/src/Action/HasStream.php
@@ -12,7 +12,6 @@ declare(strict_types=1);
 
 namespace Prooph\EventStore\Http\Middleware\Action;
 
-use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\ReadOnlyEventStore;
 use Prooph\EventStore\StreamName;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Action/LoadStream.php
+++ b/src/Action/LoadStream.php
@@ -1,0 +1,204 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Model\MetadataMatcherBuilder;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Http\Middleware\UrlHelper;
+use Prooph\EventStore\ReadOnlyEventStore;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class LoadStream implements RequestHandlerInterface
+{
+    /**
+     * @var ReadOnlyEventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var MessageConverter
+     */
+    private $messageConverter;
+
+    /**
+     * @var Transformer[]
+     */
+    private $transformers = [];
+
+    /**
+     * @var UrlHelper
+     */
+    private $urlHelper;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(
+        ReadOnlyEventStore $eventStore,
+        MessageConverter $messageConverter,
+        UrlHelper $urlHelper,
+        ResponseInterface $responsePrototype
+    ) {
+        $this->eventStore = $eventStore;
+        $this->messageConverter = $messageConverter;
+        $this->urlHelper = $urlHelper;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function addTransformer(Transformer $transformer, string ...$names)
+    {
+        foreach ($names as $name) {
+            $this->transformers[$name] = $transformer;
+        }
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $streamName = urldecode($request->getAttribute('streamname'));
+
+        if (! array_key_exists($request->getHeaderLine('Accept'), $this->transformers)) {
+            return $this->returnDescription($request, $streamName);
+        }
+
+        $transformer = $this->transformers[$request->getHeaderLine('Accept')];
+
+        $start = $request->getAttribute('start');
+
+        if ('head' === $start) {
+            $start = PHP_INT_MAX;
+        }
+
+        $start = (int) $start;
+
+        $count = (int) $request->getAttribute('count');
+
+        $direction = $request->getAttribute('direction');
+
+        if (PHP_INT_MAX === $start && 'forward' === $direction) {
+            return $this->responsePrototype->withStatus(400);
+        }
+
+        $metadataMatcherBuilder = new MetadataMatcherBuilder();
+        $metadataMatcher = $metadataMatcherBuilder->createMetadataMatcherFrom($request, true);
+
+        try {
+            if ($direction === 'backward') {
+                $streamEvents = $this->eventStore->loadReverse(new StreamName($streamName), $start, $count, $metadataMatcher);
+            } else {
+                $streamEvents = $this->eventStore->load(new StreamName($streamName), $start, $count, $metadataMatcher);
+            }
+        } catch (StreamNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        if (! $streamEvents->valid()) {
+            return $this->responsePrototype->withStatus(400, '\'' . $start . '\' is not a valid event number');
+        }
+
+        $entries = [];
+
+        foreach ($streamEvents as $event) {
+            $entry = $this->messageConverter->convertToArray($event);
+            $entry['created_at'] = $entry['created_at']->format('Y-m-d\TH:i:s.u');
+            $entries[] = $entry;
+        }
+
+        $host = $this->host($request);
+
+        $id = $host . $this->urlHelper->generate('EventStore::load', [
+                'streamname' => urlencode($streamName),
+            ]);
+
+        $result = [
+            'title' => "Event stream '$streamName'",
+            'id' => $id,
+            'streamName' => $streamName,
+            '_links' => [
+                [
+                    'uri' => $id,
+                    'relation' => 'self',
+                ],
+                [
+                    'uri' => $host . $this->urlHelper->generate('EventStore::load', [
+                            'streamname' => urlencode($streamName),
+                            'start' => '1',
+                            'direction' => 'forward',
+                            'count' => $count,
+                        ]),
+                    'relation' => 'first',
+                ],
+                [
+                    'uri' => $host . $this->urlHelper->generate('EventStore::load', [
+                            'streamname' => urlencode($streamName),
+                            'start' => 'head',
+                            'direction' => 'backward',
+                            'count' => $count,
+                        ]),
+                    'relation' => 'last',
+                ],
+            ],
+            'entries' => $entries,
+        ];
+
+        return $transformer->createResponse($result);
+    }
+
+    private function returnDescription(ServerRequestInterface $request, string $streamName): ResponseInterface
+    {
+        $id = $this->host($request) . $this->urlHelper->generate('EventStore::load', [
+            'streamname' => urlencode($streamName),
+        ]);
+
+        $body = $this->responsePrototype->getBody();
+        $body->rewind();
+        $body->write(json_encode([
+            'title' => 'Description document for \'' . $streamName . '\'',
+            'description' => 'The description document will be presented when no accept header is present or it was requested',
+            '_links' => [
+                'self' => [
+                    'href' => $id,
+                    'supportedContentTypes' => [
+                        'application/vnd.eventstore.streamdesc+json',
+                    ],
+                ],
+                'stream' => [
+                    'href' => $id,
+                    'supportedContentTypes' => array_keys($this->transformers),
+                ],
+            ],
+        ]));
+
+        return $this->responsePrototype->withStatus(200)
+            ->withAddedHeader('Content-Type', 'application/vnd.eventstore.streamdesc+json; charset=utf-8')
+            ->withBody($body);
+    }
+
+    private function host(ServerRequestInterface $request): string
+    {
+        $uri = $request->getUri();
+        $host = $uri->getScheme() . '://' . $uri->getHost();
+
+        if (null !== $uri->getPort()) {
+            $host .= ':' . $uri->getPort();
+        }
+
+        return $host;
+    }
+}

--- a/src/Action/LoadStream.php
+++ b/src/Action/LoadStream.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/PostStream.php
+++ b/src/Action/PostStream.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/PostStream.php
+++ b/src/Action/PostStream.php
@@ -1,0 +1,162 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use ArrayIterator;
+use DateTimeImmutable;
+use DateTimeZone;
+use Prooph\Common\Messaging\MessageDataAssertion;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+use Prooph\EventStore\TransactionalEventStore;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Ramsey\Uuid\Uuid;
+use Throwable;
+
+final class PostStream implements RequestHandlerInterface
+{
+    /**
+     * @var EventStore
+     */
+    private $eventStore;
+
+    /**
+     * @var MessageFactory
+     */
+    private $messageFactory;
+
+    private $validRequestContentTypes = [
+        'application/vnd.eventstore.atom+json',
+        'application/json',
+        'application/atom+json',
+    ];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(EventStore $eventStore, MessageFactory $messageFactory, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->messageFactory = $messageFactory;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        if (! in_array($request->getHeaderLine('Content-Type'), $this->validRequestContentTypes)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $readEvents = $request->getParsedBody();
+
+        if (! is_array($readEvents) || empty($readEvents)) {
+            return $this->responsePrototype->withStatus(400, 'Write request body invalid');
+        }
+
+        $events = [];
+
+        foreach ($readEvents as $event) {
+            if (! is_array($event)) {
+                return $this->responsePrototype->withStatus(400, 'Write request body invalid');
+            }
+
+            if (! isset($event['uuid'])) {
+                $event['uuid'] = Uuid::uuid4()->toString();
+            }
+
+            if (! is_string($event['uuid']) || ! Uuid::isValid($event['uuid'])) {
+                return $this->responsePrototype->withStatus(400, 'Invalid event uuid provided');
+            }
+
+            if (! isset($event['message_name'])) {
+                return $this->responsePrototype->withStatus(400, 'Empty event name provided');
+            }
+
+            if (! is_string($event['message_name']) || strlen($event['message_name']) === 0) {
+                return $this->responsePrototype->withStatus(400, 'Invalid event name provided');
+            }
+
+            if (! isset($event['payload'])) {
+                $event['payload'] = [];
+            }
+
+            try {
+                MessageDataAssertion::assertPayload($event['payload']);
+            } catch (Throwable $e) {
+                return $this->responsePrototype->withStatus(400, 'Invalid event payload provided');
+            }
+
+            if (! isset($event['metadata'])) {
+                $event['metadata'] = [];
+            }
+
+            try {
+                MessageDataAssertion::assertMetadata($event['metadata']);
+            } catch (Throwable $e) {
+                return $this->responsePrototype->withStatus(400, 'Invalid event metadata provided');
+            }
+
+            if (! isset($event['created_at'])) {
+                $event['created_at'] = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+            } else {
+                $event['created_at'] = DateTimeImmutable::createFromFormat(
+                    'Y-m-d\TH:i:s.u',
+                    $event['created_at'],
+                    new DateTimeZone('UTC')
+                );
+            }
+
+            if (! $event['created_at'] instanceof DateTimeImmutable) {
+                return $this->responsePrototype->withStatus(400, 'Invalid created at provided, expected format: Y-m-d\TH:i:s.u');
+            }
+
+            try {
+                $events[] = $this->messageFactory->createMessageFromArray($event['message_name'], $event);
+            } catch (Throwable $e) {
+                return $this->responsePrototype->withStatus(400, 'Could not create event instance');
+            }
+        }
+
+        $streamName = new StreamName(urldecode($request->getAttribute('streamname')));
+
+        if ($this->eventStore instanceof TransactionalEventStore) {
+            $this->eventStore->beginTransaction();
+        }
+
+        try {
+            if ($this->eventStore->hasStream($streamName)) {
+                $this->eventStore->appendTo($streamName, new ArrayIterator($events));
+            } else {
+                $this->eventStore->create(new Stream($streamName, new ArrayIterator($events)));
+            }
+        } catch (Throwable $e) {
+            if ($this->eventStore instanceof TransactionalEventStore) {
+                $this->eventStore->rollback();
+            }
+
+            return $this->responsePrototype->withStatus(500, 'Cannot create or append to stream');
+        }
+
+        if ($this->eventStore instanceof TransactionalEventStore) {
+            $this->eventStore->commit();
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Action/ResetProjection.php
+++ b/src/Action/ResetProjection.php
@@ -1,0 +1,51 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class ResetProjection implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $projectionName = urldecode($request->getAttribute('name'));
+
+        try {
+            $this->projectionManager->resetProjection($projectionName);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Action/ResetProjection.php
+++ b/src/Action/ResetProjection.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/StopProjection.php
+++ b/src/Action/StopProjection.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/StopProjection.php
+++ b/src/Action/StopProjection.php
@@ -1,0 +1,54 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class StopProjection implements RequestHandlerInterface
+{
+    /**
+     * @var ProjectionManager
+     */
+    private $projectionManager;
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(ProjectionManager $projectionManager, ResponseInterface $responsePrototype)
+    {
+        $this->projectionManager = $projectionManager;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    /**
+     * Handle the request and return a response.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $projectionName = urldecode($request->getAttribute('name'));
+
+        try {
+            $this->projectionManager->stopProjection($projectionName);
+        } catch (ProjectionNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Action/UpdateStreamMetadata.php
+++ b/src/Action/UpdateStreamMetadata.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Action/UpdateStreamMetadata.php
+++ b/src/Action/UpdateStreamMetadata.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+final class UpdateStreamMetadata implements RequestHandlerInterface
+{
+    /**
+     * @var EventStore
+     */
+    private $eventStore;
+
+    private $validRequestContentTypes = [
+        'application/vnd.eventstore.atom+json',
+        'application/json',
+        'application/atom+json',
+    ];
+
+    /**
+     * @var ResponseInterface
+     */
+    private $responsePrototype;
+
+    public function __construct(EventStore $eventStore, ResponseInterface $responsePrototype)
+    {
+        $this->eventStore = $eventStore;
+        $this->responsePrototype = $responsePrototype;
+    }
+
+    /**
+     * Handle the request and return a response.
+     */
+    public function handle(ServerRequestInterface $request): ResponseInterface
+    {
+        $streamName = urldecode($request->getAttribute('streamname'));
+
+        if (! in_array($request->getHeaderLine('Content-Type'), $this->validRequestContentTypes)) {
+            return $this->responsePrototype->withStatus(415);
+        }
+
+        $metadata = $request->getParsedBody();
+
+        try {
+            $this->eventStore->updateStreamMetadata(new StreamName($streamName), $metadata);
+        } catch (StreamNotFound $e) {
+            return $this->responsePrototype->withStatus(404);
+        }
+
+        return $this->responsePrototype->withStatus(204);
+    }
+}

--- a/src/Container/Action/DeleteProjectionFactory.php
+++ b/src/Container/Action/DeleteProjectionFactory.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\DeleteProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class DeleteProjectionFactory
+{
+    public function __invoke(ContainerInterface $container): DeleteProjection
+    {
+        return new DeleteProjection(
+            $container->get(ProjectionManager::class),
+            $container->get(ResponseInterface::class)
+        );
+    }
+}

--- a/src/Container/Action/DeleteProjectionFactory.php
+++ b/src/Container/Action/DeleteProjectionFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/DeleteStreamFactory.php
+++ b/src/Container/Action/DeleteStreamFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\DeleteStream;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class DeleteStreamFactory
+{
+    public function __invoke(ContainerInterface $container): DeleteStream
+    {
+        return new DeleteStream($container->get(EventStore::class), $container->get(ResponseInterface::class));
+    }
+}

--- a/src/Container/Action/DeleteStreamFactory.php
+++ b/src/Container/Action/DeleteStreamFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchCategoryNamesFactory.php
+++ b/src/Container/Action/FetchCategoryNamesFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchCategoryNamesFactory.php
+++ b/src/Container/Action/FetchCategoryNamesFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchCategoryNamesFactory
+{
+    public function __invoke(ContainerInterface $container): FetchCategoryNames
+    {
+        $actionHandler = new FetchCategoryNames($container->get(EventStore::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchCategoryNamesRegexFactory.php
+++ b/src/Container/Action/FetchCategoryNamesRegexFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchCategoryNamesRegexFactory.php
+++ b/src/Container/Action/FetchCategoryNamesRegexFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchCategoryNamesRegexFactory
+{
+    public function __invoke(ContainerInterface $container): FetchCategoryNamesRegex
+    {
+        $actionHandler = new FetchCategoryNamesRegex($container->get(EventStore::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchProjectionNamesFactory.php
+++ b/src/Container/Action/FetchProjectionNamesFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchProjectionNamesFactory.php
+++ b/src/Container/Action/FetchProjectionNamesFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchProjectionNamesFactory
+{
+    public function __invoke(ContainerInterface $container): FetchProjectionNames
+    {
+        $actionHandler = new FetchProjectionNames($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchProjectionNamesRegexFactory.php
+++ b/src/Container/Action/FetchProjectionNamesRegexFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchProjectionNamesRegexFactory.php
+++ b/src/Container/Action/FetchProjectionNamesRegexFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchProjectionNamesRegexFactory
+{
+    public function __invoke(ContainerInterface $container): FetchProjectionNamesRegex
+    {
+        $actionHandler = new FetchProjectionNamesRegex($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchProjectionStateFactory.php
+++ b/src/Container/Action/FetchProjectionStateFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchProjectionStateFactory.php
+++ b/src/Container/Action/FetchProjectionStateFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionState;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchProjectionStateFactory
+{
+    public function __invoke(ContainerInterface $container): FetchProjectionState
+    {
+        $actionHandler = new FetchProjectionState($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchProjectionStatusFactory.php
+++ b/src/Container/Action/FetchProjectionStatusFactory.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStatus;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchProjectionStatusFactory
+{
+    public function __invoke(ContainerInterface $container): FetchProjectionStatus
+    {
+        $actionHandler = new FetchProjectionStatus($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchProjectionStatusFactory.php
+++ b/src/Container/Action/FetchProjectionStatusFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchProjectionStreamPositionsFactory.php
+++ b/src/Container/Action/FetchProjectionStreamPositionsFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchProjectionStreamPositionsFactory.php
+++ b/src/Container/Action/FetchProjectionStreamPositionsFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStreamPositions;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchProjectionStreamPositionsFactory
+{
+    public function __invoke(ContainerInterface $container): FetchProjectionStreamPositions
+    {
+        $actionHandler = new FetchProjectionStreamPositions($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchStreamMetadataFactory.php
+++ b/src/Container/Action/FetchStreamMetadataFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchStreamMetadataFactory.php
+++ b/src/Container/Action/FetchStreamMetadataFactory.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamMetadata;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchStreamMetadataFactory
+{
+    public function __invoke(ContainerInterface $container): FetchStreamMetadata
+    {
+        $actionHandler = new FetchStreamMetadata($container->get(EventStore::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchStreamNamesFactory.php
+++ b/src/Container/Action/FetchStreamNamesFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchStreamNamesFactory.php
+++ b/src/Container/Action/FetchStreamNamesFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchStreamNamesFactory
+{
+    public function __invoke(ContainerInterface $container): FetchStreamNames
+    {
+        $actionHandler = new FetchStreamNames($container->get(EventStore::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/FetchStreamNamesRegexFactory.php
+++ b/src/Container/Action/FetchStreamNamesRegexFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/FetchStreamNamesRegexFactory.php
+++ b/src/Container/Action/FetchStreamNamesRegexFactory.php
@@ -1,0 +1,35 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class FetchStreamNamesRegexFactory
+{
+    public function __invoke(ContainerInterface $container): FetchStreamNamesRegex
+    {
+        $actionHandler = new FetchStreamNamesRegex($container->get(EventStore::class), $container->get(ResponseInterface::class));
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/HasStreamFactory.php
+++ b/src/Container/Action/HasStreamFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/HasStreamFactory.php
+++ b/src/Container/Action/HasStreamFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\HasStream;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class HasStreamFactory
+{
+    public function __invoke(ContainerInterface $container): HasStream
+    {
+        return new HasStream($container->get(EventStore::class), $container->get(ResponseInterface::class));
+    }
+}

--- a/src/Container/Action/LoadStreamFactory.php
+++ b/src/Container/Action/LoadStreamFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/LoadStreamFactory.php
+++ b/src/Container/Action/LoadStreamFactory.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\LoadStream;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Http\Middleware\UrlHelper;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class LoadStreamFactory
+{
+    public function __invoke(ContainerInterface $container): LoadStream
+    {
+        $actionHandler = new LoadStream(
+            $container->get(EventStore::class),
+            $container->get(MessageConverter::class),
+            $container->get(UrlHelper::class),
+            $container->get(ResponseInterface::class)
+        );
+
+        $actionHandler->addTransformer(
+            $container->get(Transformer::class),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        return $actionHandler;
+    }
+}

--- a/src/Container/Action/PostStreamFactory.php
+++ b/src/Container/Action/PostStreamFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/PostStreamFactory.php
+++ b/src/Container/Action/PostStreamFactory.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\PostStream;
+use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class PostStreamFactory
+{
+    public function __invoke(ContainerInterface $container): PostStream
+    {
+        return new PostStream(
+            $container->get(EventStore::class),
+            $container->get(GenericEventFactory::class),
+            $container->get(ResponseInterface::class)
+        );
+    }
+}

--- a/src/Container/Action/ResetProjectionFactory.php
+++ b/src/Container/Action/ResetProjectionFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\ResetProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class ResetProjectionFactory
+{
+    public function __invoke(ContainerInterface $container): ResetProjection
+    {
+        return new ResetProjection($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+    }
+}

--- a/src/Container/Action/ResetProjectionFactory.php
+++ b/src/Container/Action/ResetProjectionFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/StopProjectionFactory.php
+++ b/src/Container/Action/StopProjectionFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/StopProjectionFactory.php
+++ b/src/Container/Action/StopProjectionFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\Http\Middleware\Action\StopProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class StopProjectionFactory
+{
+    public function __invoke(ContainerInterface $container): StopProjection
+    {
+        return new StopProjection($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+    }
+}

--- a/src/Container/Action/UpdateStreamMetadataFactory.php
+++ b/src/Container/Action/UpdateStreamMetadataFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Container/Action/UpdateStreamMetadataFactory.php
+++ b/src/Container/Action/UpdateStreamMetadataFactory.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Container\Action;
+
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\UpdateStreamMetadata;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+final class UpdateStreamMetadataFactory
+{
+    public function __invoke(ContainerInterface $container): UpdateStreamMetadata
+    {
+        return new UpdateStreamMetadata($container->get(EventStore::class), $container->get(ResponseInterface::class));
+    }
+}

--- a/src/GenericEvent.php
+++ b/src/GenericEvent.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/GenericEvent.php
+++ b/src/GenericEvent.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Api;
+
+use Prooph\Common\Messaging\DomainMessage;
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\PayloadTrait;
+
+final class GenericEvent extends DomainMessage
+{
+    use PayloadTrait;
+
+    public function messageType(): string
+    {
+        return Message::TYPE_EVENT;
+    }
+}

--- a/src/GenericEvent.php
+++ b/src/GenericEvent.php
@@ -10,7 +10,7 @@
 
 declare(strict_types=1);
 
-namespace Prooph\EventStore\Http\Api;
+namespace Prooph\EventStore\Http\Middleware;
 
 use Prooph\Common\Messaging\DomainMessage;
 use Prooph\Common\Messaging\Message;

--- a/src/GenericEventFactory.php
+++ b/src/GenericEventFactory.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/GenericEventFactory.php
+++ b/src/GenericEventFactory.php
@@ -10,7 +10,7 @@
 
 declare(strict_types=1);
 
-namespace Prooph\EventStore\Http\Api;
+namespace Prooph\EventStore\Http\Middleware;
 
 use DateTimeImmutable;
 use DateTimeZone;

--- a/src/GenericEventFactory.php
+++ b/src/GenericEventFactory.php
@@ -1,0 +1,47 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Api;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Prooph\Common\Messaging\Message;
+use Prooph\Common\Messaging\MessageFactory;
+use Ramsey\Uuid\Uuid;
+
+class GenericEventFactory implements MessageFactory
+{
+    public function createMessageFromArray(string $messageName, array $messageData): Message
+    {
+        if (! isset($messageData['message_name'])) {
+            $messageData['message_name'] = $messageName;
+        }
+
+        if (! isset($messageData['uuid'])) {
+            $messageData['uuid'] = Uuid::uuid4();
+        }
+
+        if (! isset($messageData['version'])) {
+            $messageData['version'] = 0;
+        }
+
+        if (! isset($messageData['created_at'])) {
+            $messageData['created_at'] = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        }
+
+        if (! isset($messageData['metadata'])) {
+            $messageData['metadata'] = [];
+        }
+
+        return GenericEvent::fromArray($messageData);
+    }
+}

--- a/src/Model/MetadataMatcherBuilder.php
+++ b/src/Model/MetadataMatcherBuilder.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Model/MetadataMatcherBuilder.php
+++ b/src/Model/MetadataMatcherBuilder.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware\Model;
+
+use Prooph\EventStore\Metadata\FieldType;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Metadata\Operator;
+use Psr\Http\Message\ServerRequestInterface;
+
+class MetadataMatcherBuilder
+{
+    public function createMetadataMatcherFrom(ServerRequestInterface $request, bool $includeProperties): MetadataMatcher
+    {
+        $metadata = [];
+
+        if ($includeProperties) {
+            $messageProperty = [];
+        }
+
+        foreach ($request->getQueryParams() as $queryParam => $value) {
+            $matches = [];
+
+            if (preg_match('/^meta_(\d+)_field$/', $queryParam, $matches)) {
+                $metadata[$matches[1]]['field'] = $value;
+            } elseif (preg_match('/^meta_(\d+)_operator$/', $queryParam, $matches)
+                && defined(Operator::class . '::' . $value)
+            ) {
+                $metadata[$matches[1]]['operator'] = Operator::byName($value);
+            } elseif (preg_match('/^meta_(\d+)_value$/', $queryParam, $matches)) {
+                $metadata[$matches[1]]['value'] = $value;
+            } elseif ($includeProperties && preg_match('/^property_(\d+)_field$/', $queryParam, $matches)) {
+                $messageProperty[$matches[1]]['field'] = $value;
+            } elseif ($includeProperties && preg_match('/^property_(\d+)_operator$/', $queryParam, $matches)
+                && defined(Operator::class . '::' . $value)
+            ) {
+                $messageProperty[$matches[1]]['operator'] = Operator::byName($value);
+            } elseif ($includeProperties && preg_match('/^property_(\d+)_value$/', $queryParam, $matches)) {
+                $messageProperty[$matches[1]]['value'] = $value;
+            }
+        }
+
+        $metadataMatcher = new MetadataMatcher();
+
+        foreach ($metadata as $key => $match) {
+            if (isset($match['field'], $match['operator'], $match['value'])) {
+                $metadataMatcher = $metadataMatcher->withMetadataMatch(
+                    $match['field'],
+                    $match['operator'],
+                    $match['value'],
+                    FieldType::METADATA()
+                );
+            }
+        }
+
+        if (! $includeProperties) {
+            return $metadataMatcher;
+        }
+
+        foreach ($messageProperty as $key => $match) {
+            if (isset($match['field'], $match['operator'], $match['value'])) {
+                $metadataMatcher = $metadataMatcher->withMetadataMatch(
+                    $match['field'],
+                    $match['operator'],
+                    $match['value'],
+                    FieldType::MESSAGE_PROPERTY()
+                );
+            }
+        }
+
+        return $metadataMatcher;
+    }
+}

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/Transformer.php
+++ b/src/Transformer.php
@@ -1,0 +1,24 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface Transformer
+{
+    /**
+     * @param array $result
+     * @return ResponseInterface
+     */
+    public function createResponse(array $result): ResponseInterface;
+}

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/src/UrlHelper.php
+++ b/src/UrlHelper.php
@@ -1,0 +1,18 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware;
+
+interface UrlHelper
+{
+    public function generate(string $urlId, array $params = []): string;
+}

--- a/tests/Action/DeleteProjectionTest.php
+++ b/tests/Action/DeleteProjectionTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/DeleteProjectionTest.php
+++ b/tests/Action/DeleteProjectionTest.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\DeleteProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteProjectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_will_delete_projection_incl_emitted_events(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->deleteProjection('runner', true)->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+        $request->getAttribute('deleteEmittedEvents')->willReturn('true')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new DeleteProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_delete_projection_without_emitted_events(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->deleteProjection('runner', false)->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+        $request->getAttribute('deleteEmittedEvents')->willReturn('false')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new DeleteProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_when_unknown_projection_asked(): void
+    {
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+        $request->getAttribute('deleteEmittedEvents')->willReturn('true')->shouldBeCalled();
+
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->deleteProjection('runner', true)->willThrow(new ProjectionNotFound())->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new DeleteProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/DeleteStreamTest.php
+++ b/tests/Action/DeleteStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/DeleteStreamTest.php
+++ b/tests/Action/DeleteStreamTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Action\DeleteStream;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class DeleteStreamTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_404_when_stream_not_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->delete(new StreamName('unknown'))->willThrow(new StreamNotFound());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('streamname')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new DeleteStream($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_delete_stream(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->delete(new StreamName('foo\bar'))->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('streamname')->willReturn('foo\bar')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new DeleteStream($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchCategoryNamesRegexTest.php
+++ b/tests/Action/FetchCategoryNamesRegexTest.php
@@ -1,0 +1,73 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchCategoryNamesRegexTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchCategoryNamesRegex($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(new TransformerStub($responsePrototype->reveal()), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_category_names(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchCategoryNamesRegex('^foo$', 20, 0)
+            ->willReturn(['foo'])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(urlencode('^foo$'))->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $transformer->createResponse(['foo'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchCategoryNamesRegex($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchCategoryNamesRegexTest.php
+++ b/tests/Action/FetchCategoryNamesRegexTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchCategoryNamesTest.php
+++ b/tests/Action/FetchCategoryNamesTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchCategoryNamesTest.php
+++ b/tests/Action/FetchCategoryNamesTest.php
@@ -1,0 +1,102 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchCategoryNamesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchCategoryNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(new TransformerStub($responsePrototype->reveal()), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_category_names(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchCategoryNames('foo', 20, 0)
+            ->willReturn(['foo', 'foobar'])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn('foo')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchCategoryNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_all_category_names_without_filter(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchCategoryNames(null, 20, 0)
+            ->willReturn(['foo', 'foobar'])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(null)->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchCategoryNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchProjectionNamesRegexTest.php
+++ b/tests/Action/FetchProjectionNamesRegexTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchProjectionNamesRegexTest.php
+++ b/tests/Action/FetchProjectionNamesRegexTest.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchProjectionNamesRegexTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchProjectionNamesRegex($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(new TransformerStub($responsePrototype->reveal()), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_projection_names(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionNamesRegex('^foo$', 20, 0)->willReturn(['foo'])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(urlencode('^foo$'))->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchProjectionNamesRegex($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchProjectionNamesTest.php
+++ b/tests/Action/FetchProjectionNamesTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchProjectionNamesTest.php
+++ b/tests/Action/FetchProjectionNamesTest.php
@@ -1,0 +1,96 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchProjectionNamesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchProjectionNames($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(new TransformerStub($responsePrototype->reveal()), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_projection_names(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionNames('foo', 20, 0)->willReturn(['foo', 'foobar'])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn('foo')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchProjectionNames($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_all_projection_names_without_filter(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionNames(null, 20, 0)->willReturn(['foo', 'foobar'])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(null)->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchProjectionNames($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchProjectionStateTest.php
+++ b/tests/Action/FetchProjectionStateTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchProjectionStateTest.php
+++ b/tests/Action/FetchProjectionStateTest.php
@@ -1,0 +1,95 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionState;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchProjectionStateTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchProjectionState($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(new TransformerStub($responsePrototype->reveal()), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_state(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionState('foo')->willReturn(['foo' => 'bar'])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('name')->willReturn('foo')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo' => 'bar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchProjectionState($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_on_unknown_projection(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionState('unknown')->willThrow(ProjectionNotFound::withName('unknown'))->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('name')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchProjectionState($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchProjectionStatusTest.php
+++ b/tests/Action/FetchProjectionStatusTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchProjectionStatusTest.php
+++ b/tests/Action/FetchProjectionStatusTest.php
@@ -1,0 +1,66 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStatus;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Prooph\EventStore\Projection\ProjectionStatus;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchProjectionStatusTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_status(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionStatus('foo')->willReturn(ProjectionStatus::RUNNING())->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('foo')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(200, ProjectionStatus::RUNNING()->getName())->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchProjectionStatus($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_on_unknown_projection(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionStatus('unknown')->willThrow(ProjectionNotFound::withName('unknown'))->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new FetchProjectionStatus($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchProjectionStreamPositionsTest.php
+++ b/tests/Action/FetchProjectionStreamPositionsTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchProjectionStreamPositionsTest.php
+++ b/tests/Action/FetchProjectionStreamPositionsTest.php
@@ -1,0 +1,97 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStreamPositions;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchProjectionStreamPositionsTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchProjectionStreamPositions($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_stream_positions(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionStreamPositions('foo')->willReturn(['foo' => 100, 'bar' => 200])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('name')->willReturn('foo')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo' => 100, 'bar' => 200])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchProjectionStreamPositions($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_on_unknown_projection(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->fetchProjectionStreamPositions('unknown')->willThrow(ProjectionNotFound::withName('unknown'))->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('name')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchProjectionStreamPositions($projectionManager->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchStreamMetadataTest.php
+++ b/tests/Action/FetchStreamMetadataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchStreamMetadataTest.php
+++ b/tests/Action/FetchStreamMetadataTest.php
@@ -1,0 +1,100 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamMetadata;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchStreamMetadataTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/vnd.eventstore.atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_when_stream_not_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->fetchStreamMetadata(new StreamName('unknown'))->willThrow(new StreamNotFound());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/vnd.eventstore.atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_stream_metadata_using_transformer(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->fetchStreamMetadata(new StreamName('foo\bar'))->willReturn([
+            'foo' => 'bar',
+        ])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo\bar')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo' => 'bar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/vnd.eventstore.atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchStreamNamesRegexTest.php
+++ b/tests/Action/FetchStreamNamesRegexTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/FetchStreamNamesRegexTest.php
+++ b/tests/Action/FetchStreamNamesRegexTest.php
@@ -1,0 +1,119 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNamesRegex;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Metadata\FieldType;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchStreamNamesRegexTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchStreamNamesRegex($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_stream_names(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchStreamNamesRegex('^foo$', new MetadataMatcher(), 20, 0)
+            ->willReturn([new StreamName('foo')])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(urlencode('^foo$'))->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamNamesRegex($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_respects_given_metadata_in_query_params(): void
+    {
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::EQUALS(), 'bar', FieldType::METADATA());
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchStreamNamesRegex('^foo', $metadataMatcher, 20, 0)
+            ->willReturn([new StreamName('foo'), new StreamName('foobar')])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn('^foo')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([
+            'meta_0_field' => 'foo',
+            'meta_0_operator' => 'EQUALS',
+            'meta_0_value' => 'bar',
+            'meta_1_field' => 'missing_parts',
+            'meta_2_field' => 'invalid op',
+            'meta_2_operator' => 'INVALID',
+            'meta_2_value' => 'some value',
+        ])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamNamesRegex($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchStreamNamesTest.php
+++ b/tests/Action/FetchStreamNamesTest.php
@@ -1,0 +1,148 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNames;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Metadata\FieldType;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class FetchStreamNamesTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new FetchStreamNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_filtered_stream_names(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchStreamNames('foo', new MetadataMatcher(), 20, 0)
+            ->willReturn([new StreamName('foo'), new StreamName('foobar')])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn('foo')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_all_stream_names_without_filter(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchStreamNames(null, new MetadataMatcher(), 20, 0)
+            ->willReturn([new StreamName('foo'), new StreamName('foobar')])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(null)->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_respects_given_metadata_in_query_params(): void
+    {
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::EQUALS(), 'bar', FieldType::METADATA());
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore
+            ->fetchStreamNames(null, $metadataMatcher, 20, 0)
+            ->willReturn([new StreamName('foo'), new StreamName('foobar')])
+            ->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/atom+json')->shouldBeCalled();
+        $request->getAttribute('filter')->willReturn(null)->shouldBeCalled();
+        $request->getQueryParams()->willReturn([
+            'meta_0_field' => 'foo',
+            'meta_0_operator' => 'EQUALS',
+            'meta_0_value' => 'bar',
+            'meta_1_field' => 'missing_parts',
+            'meta_2_field' => 'invalid op',
+            'meta_2_operator' => 'INVALID',
+            'meta_2_value' => 'some value',
+        ])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse(['foo', 'foobar'])->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new FetchStreamNames($eventStore->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/FetchStreamNamesTest.php
+++ b/tests/Action/FetchStreamNamesTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/HasStreamTest.php
+++ b/tests/Action/HasStreamTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\HasStream;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class HasStreamTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_404_when_stream_not_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('unknown'))->willReturn(false)->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('streamname')->willReturn('unknown')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new HasStream($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_200_when_stream_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('known'))->willReturn(true)->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('streamname')->willReturn('known')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(200)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new HasStream($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/HasStreamTest.php
+++ b/tests/Action/HasStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/LoadStreamTest.php
+++ b/tests/Action/LoadStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/LoadStreamTest.php
+++ b/tests/Action/LoadStreamTest.php
@@ -1,0 +1,714 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use ArrayIterator;
+use DateTimeImmutable;
+use DateTimeZone;
+use EmptyIterator;
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\Common\Messaging\NoOpMessageConverter;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Action\LoadStream;
+use Prooph\EventStore\Http\Middleware\GenericEvent;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Http\Middleware\UrlHelper;
+use Prooph\EventStore\Metadata\FieldType;
+use Prooph\EventStore\Metadata\MetadataMatcher;
+use Prooph\EventStore\Metadata\Operator;
+use Prooph\EventStore\StreamName;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\StreamInterface;
+use Psr\Http\Message\UriInterface;
+use Ramsey\Uuid\Uuid;
+
+class LoadStreamTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_description_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getScheme()->willReturn('http');
+        $uri->getHost()->willReturn('localhost');
+        $uri->getPort()->willReturn('8080');
+        $uri->__toString()->willReturn('/stream');
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo\bar')->shouldBeCalled();
+        $request->getUri()->willReturn($uri->reveal())->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => urlencode('foo\bar'),
+        ])->willReturn($uri->reveal())->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $body = $this->prophesize(StreamInterface::class);
+        $body->rewind()->shouldBeCalled();
+        $body->write(Argument::type('string'))->shouldBeCalled();
+        $responsePrototype->getBody()->willReturn($body->reveal())->shouldBeCalled();
+        $responsePrototype->withBody($body->reveal())->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $responsePrototype->withStatus(200)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $responsePrototype->withAddedHeader('Content-Type', 'application/vnd.eventstore.streamdesc+json; charset=utf-8')
+            ->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter->reveal(), $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/vnd.eventstore.atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_bad_request(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('head')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('1')->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter->reveal(), $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer($transformer->reveal(), 'application/vnd.eventstore.atom+json');
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_loads_events(): void
+    {
+        $uuid1 = Uuid::uuid4()->toString();
+        $uuid2 = Uuid::uuid4()->toString();
+        $uuid3 = Uuid::uuid4()->toString();
+
+        $time1 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $time2 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $time3 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->load(new StreamName('foo'), 1, 3, new MetadataMatcher())->willReturn(new ArrayIterator([
+            GenericEvent::fromArray([
+                'uuid' => $uuid1,
+                'message_name' => 'message_one',
+                'created_at' => $time1,
+                'payload' => ['one'],
+                'metadata' => [],
+            ]),
+            GenericEvent::fromArray([
+                'uuid' => $uuid2,
+                'message_name' => 'message_two',
+                'created_at' => $time2,
+                'payload' => ['two'],
+                'metadata' => [],
+            ]),
+            GenericEvent::fromArray([
+                'uuid' => $uuid3,
+                'message_name' => 'message_three',
+                'created_at' => $time3,
+                'payload' => ['three'],
+                'metadata' => [],
+            ]),
+        ]))->shouldBeCalled();
+
+        $messageConverter = new NoOpMessageConverter();
+
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getScheme()->willReturn('http')->shouldBeCalled();
+        $uri->getPort()->willReturn(8080)->shouldBeCalled();
+        $uri->getHost()->willReturn('localhost')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('1')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getUri()->willReturn($uri->reveal())->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+        ])->willReturn('/stream/foo')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => '1',
+            'direction' => 'forward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/1/forward/3')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => 'head',
+            'direction' => 'backward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/head/backward/3')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse([
+            'title' => 'Event stream \'foo\'',
+            'id' => 'http://localhost:8080/stream/foo',
+            'streamName' => 'foo',
+            '_links' => [
+                [
+                    'uri' => 'http://localhost:8080/stream/foo',
+                    'relation' => 'self',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/1/forward/3',
+                    'relation' => 'first',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/head/backward/3',
+                    'relation' => 'last',
+                ],
+            ],
+            'entries' => [
+                [
+                    'message_name' => 'message_one',
+                    'uuid' => $uuid1,
+                    'payload' => [
+                        0 => 'one',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time1->format('Y-m-d\TH:i:s.u'),
+                ],
+                [
+                    'message_name' => 'message_two',
+                    'uuid' => $uuid2,
+                    'payload' => [
+                        0 => 'two',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time2->format('Y-m-d\TH:i:s.u'),
+                ],
+                [
+                    'message_name' => 'message_three',
+                    'uuid' => $uuid3,
+                    'payload' => [
+                        0 => 'three',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time3->format('Y-m-d\TH:i:s.u'),
+                ],
+            ],
+        ])->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter, $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_load_events_reverse(): void
+    {
+        $uuid1 = Uuid::uuid4()->toString();
+        $uuid2 = Uuid::uuid4()->toString();
+        $uuid3 = Uuid::uuid4()->toString();
+
+        $time1 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $time2 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $time3 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->loadReverse(new StreamName('foo'), 3, 3, new MetadataMatcher())->willReturn(new ArrayIterator([
+            GenericEvent::fromArray([
+                'uuid' => $uuid3,
+                'message_name' => 'message_three',
+                'created_at' => $time3,
+                'payload' => ['three'],
+                'metadata' => [],
+            ]),
+            GenericEvent::fromArray([
+                'uuid' => $uuid2,
+                'message_name' => 'message_two',
+                'created_at' => $time2,
+                'payload' => ['two'],
+                'metadata' => [],
+            ]),
+            GenericEvent::fromArray([
+                'uuid' => $uuid1,
+                'message_name' => 'message_one',
+                'created_at' => $time1,
+                'payload' => ['one'],
+                'metadata' => [],
+            ]),
+        ]))->shouldBeCalled();
+
+        $messageConverter = new NoOpMessageConverter();
+
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getScheme()->willReturn('http')->shouldBeCalled();
+        $uri->getPort()->willReturn(8080)->shouldBeCalled();
+        $uri->getHost()->willReturn('localhost')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('3')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('backward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getUri()->willReturn($uri->reveal())->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+        ])->willReturn('/stream/foo')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => '1',
+            'direction' => 'forward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/1/forward/3')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => 'head',
+            'direction' => 'backward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/head/backward/3')->shouldBeCalled();
+
+        $expected = [
+            'title' => 'Event stream \'foo\'',
+            'id' => 'http://localhost:8080/stream/foo',
+            'streamName' => 'foo',
+            '_links' => [
+                [
+                    'uri' => 'http://localhost:8080/stream/foo',
+                    'relation' => 'self',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/1/forward/3',
+                    'relation' => 'first',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/head/backward/3',
+                    'relation' => 'last',
+                ],
+            ],
+            'entries' => [
+                [
+                    'message_name' => 'message_three',
+                    'uuid' => $uuid3,
+                    'payload' => [
+                        0 => 'three',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time3->format('Y-m-d\TH:i:s.u'),
+                ],
+                [
+                    'message_name' => 'message_two',
+                    'uuid' => $uuid2,
+                    'payload' => [
+                        0 => 'two',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time2->format('Y-m-d\TH:i:s.u'),
+                ],
+                [
+                    'message_name' => 'message_one',
+                    'uuid' => $uuid1,
+                    'payload' => [
+                        0 => 'one',
+                    ],
+                    'metadata' => [],
+                    'created_at' => $time1->format('Y-m-d\TH:i:s.u'),
+                ],
+            ],
+        ];
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse($expected)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter, $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_return_400_status_code_on_empty_stream(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->load(new StreamName('foo'), 1, 3, new MetadataMatcher())->willReturn(new EmptyIterator());
+
+        $messageConverter = $this->prophesize(MessageConverter::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('1')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, '\'1\' is not a valid event number')->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter->reveal(), $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_return_404_status_code_on_stream_not_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->load(new StreamName('foo'), 1, 3, new MetadataMatcher())->willThrow(new StreamNotFound());
+
+        $messageConverter = $this->prophesize(MessageConverter::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('1')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getQueryParams()->willReturn([])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $transformer = $this->prophesize(Transformer::class);
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter->reveal(), $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_matched_metadata_and_properties_on_load(): void
+    {
+        $uuid1 = Uuid::uuid4()->toString();
+
+        $time1 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::EQUALS(), 'bar', FieldType::METADATA());
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('message_name', Operator::EQUALS(), 'message_one', FieldType::MESSAGE_PROPERTY());
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->load(new StreamName('foo'), 1, 3, $metadataMatcher)->willReturn(new ArrayIterator([
+            GenericEvent::fromArray([
+                'uuid' => $uuid1,
+                'message_name' => 'message_one',
+                'created_at' => $time1,
+                'payload' => ['one'],
+                'metadata' => [
+                    'foo' => 'bar',
+                ],
+            ]),
+        ]))->shouldBeCalled();
+
+        $messageConverter = new NoOpMessageConverter();
+
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getScheme()->willReturn('http')->shouldBeCalled();
+        $uri->getPort()->willReturn(8080)->shouldBeCalled();
+        $uri->getHost()->willReturn('localhost')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('1')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('forward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getUri()->willReturn($uri->reveal())->shouldBeCalled();
+        $request->getQueryParams()->willReturn([
+            'meta_0_field' => 'foo',
+            'meta_0_operator' => 'EQUALS',
+            'meta_0_value' => 'bar',
+            'meta_1_field' => 'missing_parts',
+            'meta_2_field' => 'invalid op',
+            'meta_2_operator' => 'INVALID',
+            'meta_2_value' => 'some value',
+            'property_0_field' => 'message_name',
+            'property_0_operator' => 'EQUALS',
+            'property_0_value' => 'message_one',
+            'property_1_field' => 'missing partts',
+            'property_2_field' => 'invalid_op',
+            'property_2_operator' => 'INVALID',
+            'property_2_value' => 'some value',
+        ])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+        ])->willReturn('/stream/foo')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => '1',
+            'direction' => 'forward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/1/forward/3')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => 'head',
+            'direction' => 'backward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/head/backward/3')->shouldBeCalled();
+
+        $expected = [
+            'title' => 'Event stream \'foo\'',
+            'id' => 'http://localhost:8080/stream/foo',
+            'streamName' => 'foo',
+            '_links' => [
+                [
+                    'uri' => 'http://localhost:8080/stream/foo',
+                    'relation' => 'self',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/1/forward/3',
+                    'relation' => 'first',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/head/backward/3',
+                    'relation' => 'last',
+                ],
+            ],
+            'entries' => [
+                [
+                    'message_name' => 'message_one',
+                    'uuid' => $uuid1,
+                    'payload' => [
+                        0 => 'one',
+                    ],
+                    'metadata' => [
+                        'foo' => 'bar',
+                    ],
+                    'created_at' => $time1->format('Y-m-d\TH:i:s.u'),
+                ],
+            ],
+        ];
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse($expected)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter, $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_only_matched_metadata_and_properties_on_load_reverse(): void
+    {
+        $uuid1 = Uuid::uuid4()->toString();
+
+        $time1 = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $metadataMatcher = new MetadataMatcher();
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('foo', Operator::EQUALS(), 'bar', FieldType::METADATA());
+        $metadataMatcher = $metadataMatcher->withMetadataMatch('message_name', Operator::EQUALS(), 'message_one', FieldType::MESSAGE_PROPERTY());
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->loadReverse(new StreamName('foo'), 3, 3, $metadataMatcher)->willReturn(new ArrayIterator([
+            GenericEvent::fromArray([
+                'uuid' => $uuid1,
+                'message_name' => 'message_one',
+                'created_at' => $time1,
+                'payload' => ['one'],
+                'metadata' => [
+                    'foo' => 'bar',
+                ],
+            ]),
+        ]))->shouldBeCalled();
+
+        $messageConverter = new NoOpMessageConverter();
+
+        $uri = $this->prophesize(UriInterface::class);
+        $uri->getScheme()->willReturn('http')->shouldBeCalled();
+        $uri->getPort()->willReturn(8080)->shouldBeCalled();
+        $uri->getHost()->willReturn('localhost')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Accept')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo')->shouldBeCalled();
+        $request->getAttribute('start')->willReturn('3')->shouldBeCalled();
+        $request->getAttribute('direction')->willReturn('backward')->shouldBeCalled();
+        $request->getAttribute('count')->willReturn('3')->shouldBeCalled();
+        $request->getUri()->willReturn($uri->reveal())->shouldBeCalled();
+        $request->getQueryParams()->willReturn([
+            'meta_0_field' => 'foo',
+            'meta_0_operator' => 'EQUALS',
+            'meta_0_value' => 'bar',
+            'meta_1_field' => 'missing_parts',
+            'meta_2_field' => 'invalid op',
+            'meta_2_operator' => 'INVALID',
+            'meta_2_value' => 'some value',
+            'property_0_field' => 'message_name',
+            'property_0_operator' => 'EQUALS',
+            'property_0_value' => 'message_one',
+            'property_1_field' => 'missing partts',
+            'property_2_field' => 'invalid_op',
+            'property_2_operator' => 'INVALID',
+            'property_2_value' => 'some value',
+        ])->shouldBeCalled();
+
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+        ])->willReturn('/stream/foo')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => '1',
+            'direction' => 'forward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/1/forward/3')->shouldBeCalled();
+        $urlHelper->generate('EventStore::load', [
+            'streamname' => 'foo',
+            'start' => 'head',
+            'direction' => 'backward',
+            'count' => 3,
+        ])->willReturn('/stream/foo/head/backward/3')->shouldBeCalled();
+
+        $expected = [
+            'title' => 'Event stream \'foo\'',
+            'id' => 'http://localhost:8080/stream/foo',
+            'streamName' => 'foo',
+            '_links' => [
+                [
+                    'uri' => 'http://localhost:8080/stream/foo',
+                    'relation' => 'self',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/1/forward/3',
+                    'relation' => 'first',
+                ],
+                [
+                    'uri' => 'http://localhost:8080/stream/foo/head/backward/3',
+                    'relation' => 'last',
+                ],
+            ],
+            'entries' => [
+                [
+                    'message_name' => 'message_one',
+                    'uuid' => $uuid1,
+                    'payload' => [
+                        0 => 'one',
+                    ],
+                    'metadata' => [
+                        'foo' => 'bar',
+                    ],
+                    'created_at' => $time1->format('Y-m-d\TH:i:s.u'),
+                ],
+            ],
+        ];
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $transformer = $this->prophesize(Transformer::class);
+        $transformer->createResponse($expected)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $action = new LoadStream($eventStore->reveal(), $messageConverter, $urlHelper->reveal(), $responsePrototype->reveal());
+        $action->addTransformer(
+            $transformer->reveal(),
+            'application/vnd.eventstore.atom+json',
+            'application/atom+json',
+            'application/json'
+        );
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/PostStreamTest.php
+++ b/tests/Action/PostStreamTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/PostStreamTest.php
+++ b/tests/Action/PostStreamTest.php
@@ -1,0 +1,611 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use ArrayIterator;
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\PostStream;
+use Prooph\EventStore\Http\Middleware\GenericEvent;
+use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Prooph\EventStore\Stream;
+use Prooph\EventStore\StreamName;
+use Prooph\EventStore\TransactionalEventStore;
+use Prophecy\Argument;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Ramsey\Uuid\Uuid;
+use RuntimeException;
+
+class PostStreamTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_on_invalid_content_type(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('text/html')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_request_body(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn(['invalid body'])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Write request body invalid')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_request_body_2(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn('invalid')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Write request body invalid')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_missing_event_uuid(): void
+    {
+        $this->markTestSkipped('Refactor');
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
+        $eventStore->appendTo(
+            new StreamName('test-stream'),
+            Argument::any()
+        )->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'message_name' => 'foo',
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory);
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_event_uuid(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => 'invalid',
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Invalid event uuid provided')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_missing_event_name(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Empty event name provided')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_event_name(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => '',
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Invalid event name provided')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_missing_event_payload(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
+        $eventStore->appendTo(
+            new StreamName('test-stream'),
+            Argument::any()
+        )->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_event_payload(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'payload' => 'foo',
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Invalid event payload provided')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_missing_event_metadata(): void
+    {
+        $this->markTestSkipped('Refactor');
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
+        $eventStore->appendTo(
+            new StreamName('test-stream'),
+            Argument::any()
+        )->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'payload' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory);
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+        $this->assertSame(204, $response->getStatusCode());
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_event_metadata(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => 'foo',
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Invalid event metadata provided')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_on_invalid_event_created_at(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => 'invalid',
+
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Invalid created at provided, expected format: Y-m-d\TH:i:s.u')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_400_when_event_could_not_be_instantiated(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $time = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $messageFactory = $this->prophesize(MessageFactory::class);
+        $messageFactory->createMessageFromArray('event one', [
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => $time,
+        ])->willThrow(new RuntimeException());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(400, 'Could not create event instance')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory->reveal(), $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_rolls_back_transaction_on_error_using_transactional_event_store(): void
+    {
+        $eventStore = $this->prophesize(TransactionalEventStore::class);
+        $eventStore->beginTransaction()->shouldBeCalled();
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(false)->shouldBeCalled();
+        $eventStore->create(new StreamName('test-stream'), Argument::type(ArrayIterator::class))->willThrow(new RuntimeException());
+        $eventStore->rollback()->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => Uuid::uuid4()->toString(),
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+        ]])->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(500, 'Cannot create or append to stream')->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_stream_using_transactional_event_store(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $time = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(TransactionalEventStore::class);
+        $eventStore->beginTransaction()->shouldBeCalled();
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(false)->shouldBeCalled();
+        $eventStore->create(
+            new Stream(
+                new StreamName('test-stream'),
+                new ArrayIterator([
+                    GenericEvent::fromArray([
+                        'uuid' => $uuid,
+                        'message_name' => 'event one',
+                        'payload' => [],
+                        'metadata' => [],
+                        'created_at' => $time,
+                    ]),
+                ]),
+                []
+            )
+        )->shouldBeCalled();
+        $eventStore->commit()->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => $time->format('Y-m-d\TH:i:s.u'),
+        ]])->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_to_stream_using_transactional_event_store(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $time = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(TransactionalEventStore::class);
+        $eventStore->beginTransaction()->shouldBeCalled();
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
+        $eventStore->appendTo(
+            new StreamName('test-stream'),
+            new ArrayIterator([
+                GenericEvent::fromArray([
+                    'uuid' => $uuid,
+                    'message_name' => 'event one',
+                    'payload' => [],
+                    'metadata' => [],
+                    'created_at' => $time,
+                ]),
+            ])
+        )->shouldBeCalled();
+        $eventStore->commit()->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => $time->format('Y-m-d\TH:i:s.u'),
+        ]])->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_stream_using_non_transactional_event_store(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $time = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(false)->shouldBeCalled();
+        $eventStore->create(
+            new Stream(
+                new StreamName('test-stream'),
+                new ArrayIterator([
+                    GenericEvent::fromArray([
+                        'uuid' => $uuid,
+                        'message_name' => 'event one',
+                        'payload' => [],
+                        'metadata' => [],
+                        'created_at' => $time,
+                    ]),
+                ]),
+                []
+            )
+        )->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => $time->format('Y-m-d\TH:i:s.u'),
+        ]])->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_appends_to_stream_using_non_transactional_event_store(): void
+    {
+        $uuid = Uuid::uuid4()->toString();
+        $time = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
+        $eventStore->appendTo(
+            new StreamName('test-stream'),
+            new ArrayIterator([
+                GenericEvent::fromArray([
+                    'uuid' => $uuid,
+                    'message_name' => 'event one',
+                    'payload' => [],
+                    'metadata' => [],
+                    'created_at' => $time,
+                ]),
+            ])
+        )->shouldBeCalled();
+
+        $messageFactory = new GenericEventFactory();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getParsedBody()->willReturn([[
+            'uuid' => $uuid,
+            'message_name' => 'event one',
+            'payload' => [],
+            'metadata' => [],
+            'created_at' => $time->format('Y-m-d\TH:i:s.u'),
+        ]])->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('test-stream')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/PostStreamTest.php
+++ b/tests/Action/PostStreamTest.php
@@ -99,7 +99,6 @@ class PostStreamTest extends TestCase
      */
     public function it_creates_missing_event_uuid(): void
     {
-        $this->markTestSkipped('Refactor');
         $eventStore = $this->prophesize(EventStore::class);
         $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
         $eventStore->appendTo(
@@ -121,7 +120,7 @@ class PostStreamTest extends TestCase
         $responsePrototype = $this->prophesize(ResponseInterface::class);
         $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
 
-        $action = new PostStream($eventStore->reveal(), $messageFactory);
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
         $response = $action->handle($request->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
@@ -266,7 +265,6 @@ class PostStreamTest extends TestCase
      */
     public function it_creates_missing_event_metadata(): void
     {
-        $this->markTestSkipped('Refactor');
         $eventStore = $this->prophesize(EventStore::class);
         $eventStore = $this->prophesize(EventStore::class);
         $eventStore->hasStream(new StreamName('test-stream'))->willReturn(true)->shouldBeCalled();
@@ -289,11 +287,10 @@ class PostStreamTest extends TestCase
         $responsePrototype = $this->prophesize(ResponseInterface::class);
         $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
 
-        $action = new PostStream($eventStore->reveal(), $messageFactory);
+        $action = new PostStream($eventStore->reveal(), $messageFactory, $responsePrototype->reveal());
         $response = $action->handle($request->reveal());
 
         $this->assertInstanceOf(ResponseInterface::class, $response);
-        $this->assertSame(204, $response->getStatusCode());
     }
 
     /**

--- a/tests/Action/ResetProjectionTest.php
+++ b/tests/Action/ResetProjectionTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/ResetProjectionTest.php
+++ b/tests/Action/ResetProjectionTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\ResetProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class ResetProjectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_will_delete_projection(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->resetProjection('runner')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new ResetProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_when_unknown_projection_asked(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->resetProjection('runner')->willThrow(new ProjectionNotFound())->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new ResetProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/StopProjectionTest.php
+++ b/tests/Action/StopProjectionTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/StopProjectionTest.php
+++ b/tests/Action/StopProjectionTest.php
@@ -1,0 +1,65 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Exception\ProjectionNotFound;
+use Prooph\EventStore\Http\Middleware\Action\StopProjection;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class StopProjectionTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_will_delete_projection(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->stopProjection('runner')->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new StopProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_when_unknown_projection_asked(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $projectionManager->stopProjection('runner')->willThrow(new ProjectionNotFound())->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getAttribute('name')->willReturn('runner')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new StopProjection($projectionManager->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Action/TransformerStub.php
+++ b/tests/Action/TransformerStub.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/TransformerStub.php
+++ b/tests/Action/TransformerStub.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Http\Message\ResponseInterface;
+
+final class TransformerStub implements Transformer
+{
+    /**
+     * @var ResponseInterface
+     */
+    private $result;
+
+    /**
+     * @param ResponseInterface $result
+     */
+    public function __construct(ResponseInterface $result)
+    {
+        $this->result = $result;
+    }
+
+    /**
+     * @param array $result
+     * @return ResponseInterface
+     */
+    public function createResponse(array $result): ResponseInterface
+    {
+        return $this->result;
+    }
+}

--- a/tests/Action/UpdateStreamMetadataTest.php
+++ b/tests/Action/UpdateStreamMetadataTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Action/UpdateStreamMetadataTest.php
+++ b/tests/Action/UpdateStreamMetadataTest.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Exception\StreamNotFound;
+use Prooph\EventStore\Http\Middleware\Action\UpdateStreamMetadata;
+use Prooph\EventStore\StreamName;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+class UpdateStreamMetadataTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_415_when_invalid_accept_header_sent(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo\bar')->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(415)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new UpdateStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_returns_404_when_stream_not_found(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->updateStreamMetadata(new StreamName('unknown'), ['foo' => 'bar'])->willThrow(new StreamNotFound());
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('unknown')->shouldBeCalled();
+        $request->getParsedBody()->willReturn(['foo' => 'bar'])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(404)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new UpdateStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_update_stream_metadata(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $eventStore->updateStreamMetadata(new StreamName('foo\bar'), ['foo' => 'bar'])->shouldBeCalled();
+
+        $request = $this->prophesize(ServerRequestInterface::class);
+        $request->getHeaderLine('Content-Type')->willReturn('application/vnd.eventstore.atom+json')->shouldBeCalled();
+        $request->getAttribute('streamname')->willReturn('foo\bar')->shouldBeCalled();
+        $request->getParsedBody()->willReturn(['foo' => 'bar'])->shouldBeCalled();
+
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $responsePrototype->withStatus(204)->willReturn($responsePrototype)->shouldBeCalled();
+
+        $action = new UpdateStreamMetadata($eventStore->reveal(), $responsePrototype->reveal());
+
+        $response = $action->handle($request->reveal());
+
+        $this->assertInstanceOf(ResponseInterface::class, $response);
+    }
+}

--- a/tests/Container/Action/DeleteProjectionFactoryTest.php
+++ b/tests/Container/Action/DeleteProjectionFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/DeleteProjectionFactoryTest.php
+++ b/tests/Container/Action/DeleteProjectionFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\DeleteProjection;
+use Prooph\EventStore\Http\Middleware\Container\Action\DeleteProjectionFactory;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DeleteProjectionFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_delete_stream_action(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new DeleteProjectionFactory();
+        $action = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(DeleteProjection::class, $action);
+    }
+}

--- a/tests/Container/Action/DeleteStreamFactoryTest.php
+++ b/tests/Container/Action/DeleteStreamFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/DeleteStreamFactoryTest.php
+++ b/tests/Container/Action/DeleteStreamFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\DeleteStream;
+use Prooph\EventStore\Http\Middleware\Container\Action\DeleteStreamFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class DeleteStreamFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_delete_stream_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new DeleteStreamFactory();
+        $action = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(DeleteStream::class, $action);
+    }
+}

--- a/tests/Container/Action/FetchCategoryNamesFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchCategoryNamesFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNames;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchCategoryNamesFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchCategoryNamesFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchCategoryNamesFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchCategoryNames::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNamesRegex;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchCategoryNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchCategoryNamesRegexFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchCategoryNamesRegexFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchCategoryNamesRegex::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionNamesFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNames;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionNamesFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchProjectionNamesFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchProjectionNamesFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchProjectionNames::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionNamesFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNamesRegex;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchProjectionNamesRegexFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchProjectionNamesRegexFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchProjectionNamesRegex::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchProjectionStateFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStateFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionState;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStateFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchProjectionStateFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchProjectionStateFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchProjectionState::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionStateFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStateFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchProjectionStatusFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStatusFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchProjectionStatusFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStatusFactoryTest.php
@@ -1,0 +1,42 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStatus;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStatusFactory;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchProjectionStatusFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new FetchProjectionStatusFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchProjectionStatus::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStreamPositions;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStreamPositionsFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchProjectionStreamPositionsFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchProjectionStreamPositionsFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchProjectionStreamPositions::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/FetchStreamMetadataFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/FetchStreamMetadataFactoryTest.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamMetadata;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamMetadataFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchStreamMetadataFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_fetch_stream_metadata_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchStreamMetadataFactory();
+        $action = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(FetchStreamMetadata::class, $action);
+    }
+}

--- a/tests/Container/Action/FetchStreamNamesFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchStreamNamesFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNames;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamNamesFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchStreamNamesFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchStreamNamesFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchStreamNames::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\FetchStreamNamesRegex;
+use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class FetchStreamNamesRegexFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_returns_action_handler(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new FetchStreamNamesRegexFactory();
+
+        $actionHandler = $factory($container->reveal());
+
+        $this->assertInstanceOf(FetchStreamNamesRegex::class, $actionHandler);
+    }
+}

--- a/tests/Container/Action/HasStreamFactoryTest.php
+++ b/tests/Container/Action/HasStreamFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/HasStreamFactoryTest.php
+++ b/tests/Container/Action/HasStreamFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\HasStream;
+use Prooph\EventStore\Http\Middleware\Container\Action\HasStreamFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class HasStreamFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_fetch_stream_metadata_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new HasStreamFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(HasStream::class, $stream);
+    }
+}

--- a/tests/Container/Action/LoadStreamFactoryTest.php
+++ b/tests/Container/Action/LoadStreamFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/LoadStreamFactoryTest.php
+++ b/tests/Container/Action/LoadStreamFactoryTest.php
@@ -1,0 +1,50 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\MessageConverter;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\LoadStream;
+use Prooph\EventStore\Http\Middleware\Container\Action\LoadStreamFactory;
+use Prooph\EventStore\Http\Middleware\Transformer;
+use Prooph\EventStore\Http\Middleware\UrlHelper;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class LoadStreamFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_load_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageConverter = $this->prophesize(MessageConverter::class);
+        $urlHelper = $this->prophesize(UrlHelper::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+        $transformer = $this->prophesize(Transformer::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(MessageConverter::class)->willReturn($messageConverter->reveal())->shouldBeCalled();
+        $container->get(UrlHelper::class)->willReturn($urlHelper->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
+
+        $factory = new LoadStreamFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(LoadStream::class, $stream);
+    }
+}

--- a/tests/Container/Action/PostStreamFactoryTest.php
+++ b/tests/Container/Action/PostStreamFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/PostStreamFactoryTest.php
+++ b/tests/Container/Action/PostStreamFactoryTest.php
@@ -1,0 +1,45 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\MessageFactory;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\PostStream;
+use Prooph\EventStore\Http\Middleware\Container\Action\PostStreamFactory;
+use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class PostStreamFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_post_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $messageFactory = $this->prophesize(MessageFactory::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(GenericEventFactory::class)->willReturn($messageFactory->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new PostStreamFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(PostStream::class, $stream);
+    }
+}

--- a/tests/Container/Action/ResetProjectionFactoryTest.php
+++ b/tests/Container/Action/ResetProjectionFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/ResetProjectionFactoryTest.php
+++ b/tests/Container/Action/ResetProjectionFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\ResetProjection;
+use Prooph\EventStore\Http\Middleware\Container\Action\ResetProjectionFactory;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class ResetProjectionFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_delete_stream_action(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new ResetProjectionFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(ResetProjection::class, $stream);
+    }
+}

--- a/tests/Container/Action/StopProjectionFactoryTest.php
+++ b/tests/Container/Action/StopProjectionFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/StopProjectionFactoryTest.php
+++ b/tests/Container/Action/StopProjectionFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\Http\Middleware\Action\StopProjection;
+use Prooph\EventStore\Http\Middleware\Container\Action\StopProjectionFactory;
+use Prooph\EventStore\Projection\ProjectionManager;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class StopProjectionFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_delete_stream_action(): void
+    {
+        $projectionManager = $this->prophesize(ProjectionManager::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new StopProjectionFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(StopProjection::class, $stream);
+    }
+}

--- a/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
@@ -1,0 +1,41 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware\Container\Action;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\EventStore\EventStore;
+use Prooph\EventStore\Http\Middleware\Action\UpdateStreamMetadata;
+use Prooph\EventStore\Http\Middleware\Container\Action\UpdateStreamMetadataFactory;
+use Psr\Container\ContainerInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class UpdateStreamMetadataFactoryTest extends TestCase
+{
+    /**
+     * @test
+     */
+    public function it_creates_new_Update_stream_metadata_action(): void
+    {
+        $eventStore = $this->prophesize(EventStore::class);
+        $responsePrototype = $this->prophesize(ResponseInterface::class);
+
+        $container = $this->prophesize(ContainerInterface::class);
+        $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
+        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+
+        $factory = new UpdateStreamMetadataFactory();
+        $stream = $factory->__invoke($container->reveal());
+
+        $this->assertInstanceOf(UpdateStreamMetadata::class, $stream);
+    }
+}

--- a/tests/GenericEventFactoryTest.php
+++ b/tests/GenericEventFactoryTest.php
@@ -1,8 +1,8 @@
 <?php
 /**
  * This file is part of the prooph/event-store-http-middleware.
- * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
- * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
  *
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.

--- a/tests/GenericEventFactoryTest.php
+++ b/tests/GenericEventFactoryTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2016-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2016-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace ProophTest\EventStore\Http\Middleware;
+
+use PHPUnit\Framework\TestCase;
+use Prooph\Common\Messaging\Message;
+use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Ramsey\Uuid\Uuid;
+
+class GenericEventFactoryTest extends TestCase
+{
+    /**
+     * @var GenericEventFactory
+     */
+    private $messageFactory;
+
+    protected function setUp()
+    {
+        $this->messageFactory = new GenericEventFactory();
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_new_message_from_array(): void
+    {
+        $uuid = Uuid::uuid4();
+        $createdAt = new \DateTimeImmutable();
+
+        $event = $this->messageFactory->createMessageFromArray('happened', [
+            'uuid' => $uuid->toString(),
+            'payload' => ['command' => 'payload'],
+            'metadata' => ['command' => 'metadata'],
+            'created_at' => $createdAt,
+        ]);
+
+        $this->assertEquals('happened', $event->messageName());
+        $this->assertEquals($uuid->toString(), $event->uuid()->toString());
+        $this->assertEquals($createdAt, $event->createdAt());
+        $this->assertEquals(['command' => 'payload'], $event->payload());
+        $this->assertEquals(['command' => 'metadata'], $event->metadata());
+    }
+
+    /**
+     * @test
+     */
+    public function it_creates_a_new_message_with_defaults_from_array(): void
+    {
+        $event = $this->messageFactory->createMessageFromArray('happened', [
+            'payload' => ['command' => 'payload'],
+        ]);
+
+        $this->assertEquals('happened', $event->messageName());
+        $this->assertEquals(['command' => 'payload'], $event->payload());
+        $this->assertEquals([], $event->metadata());
+        $this->assertEquals(Message::TYPE_EVENT, $event->messageType());
+    }
+}


### PR DESCRIPTION
Actions + factories from event-store-http-api, see https://github.com/prooph/event-store-http-api/issues/34

- All actions use a ResponsePrototype now
- All actions implement PSR-15 RequestHandlerInterface
- Factories require ResponsePrototype to be registered as a service in the container using id `ResponseInterface::class`
- Factories require default transformer to be registered as a service in the contaienr using id `Transformer::class`
- `UrlHelper` is defined as an interface