### PR TITLE
Add ResponsePrototype marker interface

### DIFF
--- a/src/Container/Action/DeleteProjectionFactory.php
+++ b/src/Container/Action/DeleteProjectionFactory.php
@@ -13,9 +13,9 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\DeleteProjection;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class DeleteProjectionFactory
 {
@@ -23,7 +23,7 @@ final class DeleteProjectionFactory
     {
         return new DeleteProjection(
             $container->get(ProjectionManager::class),
-            $container->get(ResponseInterface::class)
+            $container->get(ResponsePrototype::class)
         );
     }
 }

--- a/src/Container/Action/DeleteStreamFactory.php
+++ b/src/Container/Action/DeleteStreamFactory.php
@@ -14,13 +14,13 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\DeleteStream;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class DeleteStreamFactory
 {
     public function __invoke(ContainerInterface $container): DeleteStream
     {
-        return new DeleteStream($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        return new DeleteStream($container->get(EventStore::class), $container->get(ResponsePrototype::class));
     }
 }

--- a/src/Container/Action/FetchCategoryNamesFactory.php
+++ b/src/Container/Action/FetchCategoryNamesFactory.php
@@ -14,15 +14,15 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNames;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchCategoryNamesFactory
 {
     public function __invoke(ContainerInterface $container): FetchCategoryNames
     {
-        $actionHandler = new FetchCategoryNames($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchCategoryNames($container->get(EventStore::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchCategoryNamesRegexFactory.php
+++ b/src/Container/Action/FetchCategoryNamesRegexFactory.php
@@ -14,15 +14,15 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNamesRegex;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchCategoryNamesRegexFactory
 {
     public function __invoke(ContainerInterface $container): FetchCategoryNamesRegex
     {
-        $actionHandler = new FetchCategoryNamesRegex($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchCategoryNamesRegex($container->get(EventStore::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchProjectionNamesFactory.php
+++ b/src/Container/Action/FetchProjectionNamesFactory.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNames;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchProjectionNamesFactory
 {
     public function __invoke(ContainerInterface $container): FetchProjectionNames
     {
-        $actionHandler = new FetchProjectionNames($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchProjectionNames($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchProjectionNamesRegexFactory.php
+++ b/src/Container/Action/FetchProjectionNamesRegexFactory.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNamesRegex;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchProjectionNamesRegexFactory
 {
     public function __invoke(ContainerInterface $container): FetchProjectionNamesRegex
     {
-        $actionHandler = new FetchProjectionNamesRegex($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchProjectionNamesRegex($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchProjectionStateFactory.php
+++ b/src/Container/Action/FetchProjectionStateFactory.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionState;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchProjectionStateFactory
 {
     public function __invoke(ContainerInterface $container): FetchProjectionState
     {
-        $actionHandler = new FetchProjectionState($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchProjectionState($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchProjectionStatusFactory.php
+++ b/src/Container/Action/FetchProjectionStatusFactory.php
@@ -13,15 +13,15 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStatus;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchProjectionStatusFactory
 {
     public function __invoke(ContainerInterface $container): FetchProjectionStatus
     {
-        $actionHandler = new FetchProjectionStatus($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchProjectionStatus($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
 
         return $actionHandler;
     }

--- a/src/Container/Action/FetchProjectionStreamPositionsFactory.php
+++ b/src/Container/Action/FetchProjectionStreamPositionsFactory.php
@@ -13,16 +13,16 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStreamPositions;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchProjectionStreamPositionsFactory
 {
     public function __invoke(ContainerInterface $container): FetchProjectionStreamPositions
     {
-        $actionHandler = new FetchProjectionStreamPositions($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchProjectionStreamPositions($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchStreamMetadataFactory.php
+++ b/src/Container/Action/FetchStreamMetadataFactory.php
@@ -14,15 +14,15 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamMetadata;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchStreamMetadataFactory
 {
     public function __invoke(ContainerInterface $container): FetchStreamMetadata
     {
-        $actionHandler = new FetchStreamMetadata($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchStreamMetadata($container->get(EventStore::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchStreamNamesFactory.php
+++ b/src/Container/Action/FetchStreamNamesFactory.php
@@ -14,15 +14,15 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamNames;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchStreamNamesFactory
 {
     public function __invoke(ContainerInterface $container): FetchStreamNames
     {
-        $actionHandler = new FetchStreamNames($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchStreamNames($container->get(EventStore::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/FetchStreamNamesRegexFactory.php
+++ b/src/Container/Action/FetchStreamNamesRegexFactory.php
@@ -14,15 +14,15 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamNamesRegex;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class FetchStreamNamesRegexFactory
 {
     public function __invoke(ContainerInterface $container): FetchStreamNamesRegex
     {
-        $actionHandler = new FetchStreamNamesRegex($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        $actionHandler = new FetchStreamNamesRegex($container->get(EventStore::class), $container->get(ResponsePrototype::class));
 
         $actionHandler->addTransformer(
             $container->get(Transformer::class),

--- a/src/Container/Action/HasStreamFactory.php
+++ b/src/Container/Action/HasStreamFactory.php
@@ -14,13 +14,13 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\HasStream;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class HasStreamFactory
 {
     public function __invoke(ContainerInterface $container): HasStream
     {
-        return new HasStream($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        return new HasStream($container->get(EventStore::class), $container->get(ResponsePrototype::class));
     }
 }

--- a/src/Container/Action/LoadStreamFactory.php
+++ b/src/Container/Action/LoadStreamFactory.php
@@ -15,10 +15,10 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\LoadStream;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Http\Middleware\UrlHelper;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class LoadStreamFactory
 {
@@ -28,7 +28,7 @@ final class LoadStreamFactory
             $container->get(EventStore::class),
             $container->get(MessageConverter::class),
             $container->get(UrlHelper::class),
-            $container->get(ResponseInterface::class)
+            $container->get(ResponsePrototype::class)
         );
 
         $actionHandler->addTransformer(

--- a/src/Container/Action/PostStreamFactory.php
+++ b/src/Container/Action/PostStreamFactory.php
@@ -15,8 +15,8 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\PostStream;
 use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class PostStreamFactory
 {
@@ -25,7 +25,7 @@ final class PostStreamFactory
         return new PostStream(
             $container->get(EventStore::class),
             $container->get(GenericEventFactory::class),
-            $container->get(ResponseInterface::class)
+            $container->get(ResponsePrototype::class)
         );
     }
 }

--- a/src/Container/Action/ResetProjectionFactory.php
+++ b/src/Container/Action/ResetProjectionFactory.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\ResetProjection;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class ResetProjectionFactory
 {
     public function __invoke(ContainerInterface $container): ResetProjection
     {
-        return new ResetProjection($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        return new ResetProjection($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
     }
 }

--- a/src/Container/Action/StopProjectionFactory.php
+++ b/src/Container/Action/StopProjectionFactory.php
@@ -13,14 +13,14 @@ declare(strict_types=1);
 namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\Http\Middleware\Action\StopProjection;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class StopProjectionFactory
 {
     public function __invoke(ContainerInterface $container): StopProjection
     {
-        return new StopProjection($container->get(ProjectionManager::class), $container->get(ResponseInterface::class));
+        return new StopProjection($container->get(ProjectionManager::class), $container->get(ResponsePrototype::class));
     }
 }

--- a/src/Container/Action/UpdateStreamMetadataFactory.php
+++ b/src/Container/Action/UpdateStreamMetadataFactory.php
@@ -14,13 +14,13 @@ namespace Prooph\EventStore\Http\Middleware\Container\Action;
 
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\UpdateStreamMetadata;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
-use Psr\Http\Message\ResponseInterface;
 
 final class UpdateStreamMetadataFactory
 {
     public function __invoke(ContainerInterface $container): UpdateStreamMetadata
     {
-        return new UpdateStreamMetadata($container->get(EventStore::class), $container->get(ResponseInterface::class));
+        return new UpdateStreamMetadata($container->get(EventStore::class), $container->get(ResponsePrototype::class));
     }
 }

--- a/src/ResponsePrototype.php
+++ b/src/ResponsePrototype.php
@@ -1,0 +1,19 @@
+<?php
+/**
+ * This file is part of the prooph/event-store-http-middleware.
+ * (c) 2018-2018 prooph software GmbH <contact@prooph.de>
+ * (c) 2018-2018 Sascha-Oliver Prolic <saschaprolic@googlemail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+declare(strict_types=1);
+
+namespace Prooph\EventStore\Http\Middleware;
+
+use Psr\Http\Message\ResponseInterface;
+
+interface ResponsePrototype extends ResponseInterface
+{
+}

--- a/tests/Container/Action/DeleteProjectionFactoryTest.php
+++ b/tests/Container/Action/DeleteProjectionFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\DeleteProjection;
 use Prooph\EventStore\Http\Middleware\Container\Action\DeleteProjectionFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +32,7 @@ class DeleteProjectionFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new DeleteProjectionFactory();
         $action = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/DeleteStreamFactoryTest.php
+++ b/tests/Container/Action/DeleteStreamFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\DeleteStream;
 use Prooph\EventStore\Http\Middleware\Container\Action\DeleteStreamFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -31,7 +32,7 @@ class DeleteStreamFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new DeleteStreamFactory();
         $action = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/FetchCategoryNamesFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNames;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchCategoryNamesFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ class FetchCategoryNamesFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchCategoryNamesFactory();

--- a/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchCategoryNamesRegexFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchCategoryNamesRegex;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchCategoryNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ class FetchCategoryNamesRegexFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchCategoryNamesRegexFactory();

--- a/tests/Container/Action/FetchProjectionNamesFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNames;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionNamesFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
@@ -33,7 +34,7 @@ class FetchProjectionNamesFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchProjectionNamesFactory();

--- a/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionNamesRegexFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionNamesRegex;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
@@ -33,7 +34,7 @@ class FetchProjectionNamesRegexFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchProjectionNamesRegexFactory();

--- a/tests/Container/Action/FetchProjectionStateFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStateFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionState;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStateFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
@@ -33,7 +34,7 @@ class FetchProjectionStateFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchProjectionStateFactory();

--- a/tests/Container/Action/FetchProjectionStatusFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStatusFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStatus;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStatusFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +32,7 @@ class FetchProjectionStatusFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new FetchProjectionStatusFactory();
 

--- a/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
+++ b/tests/Container/Action/FetchProjectionStreamPositionsFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\FetchProjectionStreamPositions;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchProjectionStreamPositionsFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
@@ -33,7 +34,7 @@ class FetchProjectionStreamPositionsFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchProjectionStreamPositionsFactory();

--- a/tests/Container/Action/FetchStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/FetchStreamMetadataFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamMetadata;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamMetadataFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ class FetchStreamMetadataFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchStreamMetadataFactory();

--- a/tests/Container/Action/FetchStreamNamesFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamNames;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamNamesFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ class FetchStreamNamesFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchStreamNamesFactory();

--- a/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
+++ b/tests/Container/Action/FetchStreamNamesRegexFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\FetchStreamNamesRegex;
 use Prooph\EventStore\Http\Middleware\Container\Action\FetchStreamNamesRegexFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -33,7 +34,7 @@ class FetchStreamNamesRegexFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new FetchStreamNamesRegexFactory();

--- a/tests/Container/Action/HasStreamFactoryTest.php
+++ b/tests/Container/Action/HasStreamFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\HasStream;
 use Prooph\EventStore\Http\Middleware\Container\Action\HasStreamFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -31,7 +32,7 @@ class HasStreamFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new HasStreamFactory();
         $stream = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/LoadStreamFactoryTest.php
+++ b/tests/Container/Action/LoadStreamFactoryTest.php
@@ -17,6 +17,7 @@ use Prooph\Common\Messaging\MessageConverter;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\LoadStream;
 use Prooph\EventStore\Http\Middleware\Container\Action\LoadStreamFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Http\Middleware\Transformer;
 use Prooph\EventStore\Http\Middleware\UrlHelper;
 use Psr\Container\ContainerInterface;
@@ -39,7 +40,7 @@ class LoadStreamFactoryTest extends TestCase
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
         $container->get(MessageConverter::class)->willReturn($messageConverter->reveal())->shouldBeCalled();
         $container->get(UrlHelper::class)->willReturn($urlHelper->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
         $container->get(Transformer::class)->willReturn($transformer->reveal())->shouldBeCalled();
 
         $factory = new LoadStreamFactory();

--- a/tests/Container/Action/PostStreamFactoryTest.php
+++ b/tests/Container/Action/PostStreamFactoryTest.php
@@ -18,6 +18,7 @@ use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\PostStream;
 use Prooph\EventStore\Http\Middleware\Container\Action\PostStreamFactory;
 use Prooph\EventStore\Http\Middleware\GenericEventFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -35,7 +36,7 @@ class PostStreamFactoryTest extends TestCase
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
         $container->get(GenericEventFactory::class)->willReturn($messageFactory->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new PostStreamFactory();
         $stream = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/ResetProjectionFactoryTest.php
+++ b/tests/Container/Action/ResetProjectionFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\ResetProjection;
 use Prooph\EventStore\Http\Middleware\Container\Action\ResetProjectionFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +32,7 @@ class ResetProjectionFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new ResetProjectionFactory();
         $stream = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/StopProjectionFactoryTest.php
+++ b/tests/Container/Action/StopProjectionFactoryTest.php
@@ -15,6 +15,7 @@ namespace ProophTest\EventStore\Http\Middleware\Container\Action;
 use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\Http\Middleware\Action\StopProjection;
 use Prooph\EventStore\Http\Middleware\Container\Action\StopProjectionFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Prooph\EventStore\Projection\ProjectionManager;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
@@ -31,7 +32,7 @@ class StopProjectionFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(ProjectionManager::class)->willReturn($projectionManager->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new StopProjectionFactory();
         $stream = $factory->__invoke($container->reveal());

--- a/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
+++ b/tests/Container/Action/UpdateStreamMetadataFactoryTest.php
@@ -16,6 +16,7 @@ use PHPUnit\Framework\TestCase;
 use Prooph\EventStore\EventStore;
 use Prooph\EventStore\Http\Middleware\Action\UpdateStreamMetadata;
 use Prooph\EventStore\Http\Middleware\Container\Action\UpdateStreamMetadataFactory;
+use Prooph\EventStore\Http\Middleware\ResponsePrototype;
 use Psr\Container\ContainerInterface;
 use Psr\Http\Message\ResponseInterface;
 
@@ -31,7 +32,7 @@ class UpdateStreamMetadataFactoryTest extends TestCase
 
         $container = $this->prophesize(ContainerInterface::class);
         $container->get(EventStore::class)->willReturn($eventStore->reveal())->shouldBeCalled();
-        $container->get(ResponseInterface::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
+        $container->get(ResponsePrototype::class)->willReturn($responsePrototype->reveal())->shouldBeCalled();
 
         $factory = new UpdateStreamMetadataFactory();
         $stream = $factory->__invoke($container->reveal());


### PR DESCRIPTION
to avoid conflicts if `Psr\Http\Message\ResponseInterface` is already used as service id, like it is done in expressive: https://github.com/zendframework/zend-expressive/blob/master/src/ConfigProvider.php#L56